### PR TITLE
[FEAT] 번개 생성, 조회, 수정, 삭제 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ subprojects {
     apply(plugin = "idea")
     apply(plugin = "kotlin")
     apply(plugin = "kotlin-kapt")
+    apply(plugin = "kotlin-allopen")
 
     apply(plugin = "io.spring.dependency-management")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
@@ -77,6 +78,14 @@ subprojects {
         testImplementation("io.kotest:kotest-framework-datatest:_")
         testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:_")
         testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:_")
+    }
+
+    allOpen {
+        annotations(
+            "javax.inject.Named",
+            "javax.transaction.Transactional",
+            "jakarta.inject.Named",
+        )
     }
 }
 

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
@@ -81,6 +81,20 @@ class Rendezvous(
         participants = newParticipantList
     }
 
+    fun updateByCreator(
+        title: String,
+        appointmentTime: LocalDateTime,
+        location: String,
+        requiredParticipantsCount: Int,
+        description: String? = null,
+    ) {
+        this.title = title
+        this.appointmentTime = appointmentTime
+        this.location = location
+        this.requiredParticipantsCount = requiredParticipantsCount
+        if (!description.isNullOrBlank()) this.description = description
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
@@ -7,6 +7,7 @@ import com.zoin.rendezvous.domain.user.User
 import org.hibernate.annotations.SQLDelete
 import java.time.LocalDateTime
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -45,7 +46,7 @@ class Rendezvous(
     var title: String = title
         private set
 
-    var discription: String? = description
+    var description: String? = description
         private set
 
     var appointmentTime: LocalDateTime = appointmentTime
@@ -60,7 +61,7 @@ class Rendezvous(
     var isClosedByCreator: Boolean = false
         private set
 
-    @ManyToMany(mappedBy = "belongsToRendezvous")
+    @ManyToMany(fetch = FetchType.LAZY, mappedBy = "belongsToRendezvous")
     var participants: List<User> = participants
         private set
 
@@ -99,6 +100,6 @@ class Rendezvous(
     }
 
     override fun toString(): String {
-        return "Rendezvous(author=$creator, deletedAt=$deletedAt, id=$id, title='$title', datetime=$appointmentTime, place='$location', discription=$discription)"
+        return "Rendezvous(author=$creator, deletedAt=$deletedAt, id=$id, title='$title', datetime=$appointmentTime, place='$location', discription=$description)"
     }
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousCustomRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousCustomRepository.kt
@@ -1,0 +1,7 @@
+package com.zoin.rendezvous.domain.rendezvous.repository
+
+import com.zoin.rendezvous.domain.rendezvous.Rendezvous
+
+interface RendezvousCustomRepository {
+    fun findByIdExcludeDeleted(id: Long): Rendezvous
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepository.kt
@@ -3,4 +3,4 @@ package com.zoin.rendezvous.domain.rendezvous.repository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface RendezvousRepository : RendezvousJpaRepository
+interface RendezvousRepository : RendezvousJpaRepository, RendezvousCustomRepository

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepositoryImpl.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.zoin.rendezvous.domain.rendezvous.repository
+
+import com.zoin.rendezvous.domain.rendezvous.Rendezvous
+import org.springframework.stereotype.Component
+import java.lang.IllegalArgumentException
+
+@Component
+class RendezvousRepositoryImpl(
+    private val rendezvousJpaRepository: RendezvousJpaRepository,
+) : RendezvousCustomRepository {
+    override fun findByIdExcludeDeleted(id: Long): Rendezvous {
+        val rendezvous = rendezvousJpaRepository.findById(id).orElseThrow { IllegalArgumentException("Rendezvous not found. id: $id") }
+        if (rendezvous.deletedAt != null) throw IllegalStateException("The rendezvous(id: $id) was deleted.")
+        return rendezvous
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/CreateRendezvousUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/CreateRendezvousUseCase.kt
@@ -1,0 +1,37 @@
+package com.zoin.rendezvous.domain.rendezvous.usecase
+
+import com.zoin.rendezvous.domain.rendezvous.Rendezvous
+import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import java.time.LocalDateTime
+import javax.inject.Named
+
+@Named
+class CreateRendezvousUseCase(
+    private val userRepository: UserRepository,
+    private val rendezvousRepository: RendezvousRepository,
+) {
+    data class Command(
+        val userId: Long,
+        val title: String,
+        val appointmentTime: LocalDateTime,
+        val location: String,
+        val requiredParticipantsCount: Int,
+        val description: String? = null,
+    )
+
+    fun execute(command: Command) {
+        val (userId, title, appointmentTime, location, requiredParticipantsCount, description) = command
+        val creator =
+            userRepository.findById(userId).orElseThrow { IllegalArgumentException("user not found. userId: $userId") }
+        val newRendezvous = Rendezvous(
+            creator = creator,
+            title = title,
+            appointmentTime = appointmentTime,
+            location = location,
+            requiredParticipantsCount = requiredParticipantsCount,
+            description = description,
+        )
+        rendezvousRepository.save(newRendezvous)
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/CreateRendezvousUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/CreateRendezvousUseCase.kt
@@ -12,7 +12,7 @@ class CreateRendezvousUseCase(
     private val rendezvousRepository: RendezvousRepository,
 ) {
     data class Command(
-        val userId: Long,
+        val creatorId: Long,
         val title: String,
         val appointmentTime: LocalDateTime,
         val location: String,
@@ -21,9 +21,9 @@ class CreateRendezvousUseCase(
     )
 
     fun execute(command: Command) {
-        val (userId, title, appointmentTime, location, requiredParticipantsCount, description) = command
+        val (creatorId, title, appointmentTime, location, requiredParticipantsCount, description) = command
         val creator =
-            userRepository.findById(userId).orElseThrow { IllegalArgumentException("user not found. userId: $userId") }
+            userRepository.findById(creatorId).orElseThrow { IllegalArgumentException("user not found. userId: $creatorId") }
         val newRendezvous = Rendezvous(
             creator = creator,
             title = title,

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/DeleteRendezvousUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/DeleteRendezvousUseCase.kt
@@ -1,0 +1,26 @@
+package com.zoin.rendezvous.domain.rendezvous.usecase
+
+import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import javax.inject.Named
+
+@Named
+class DeleteRendezvousUseCase(
+    private val userRepository: UserRepository,
+    private val rendezvousRepository: RendezvousRepository,
+) {
+    data class Command(
+        val userId: Long,
+        val rendezvousId: Long,
+    )
+
+    fun execute(command: Command) {
+        val deleteAgent = userRepository.findById(command.userId)
+            .orElseThrow { IllegalArgumentException("User not found. user id: ${command.userId}") }
+        val rendezvous = rendezvousRepository.findByIdExcludeDeleted(command.rendezvousId)
+
+        if (rendezvous.creator != deleteAgent) throw IllegalAccessException("Only creator can delete reandezvous.")
+
+        deleteAgent.deleteRendezvous(rendezvousRepository, rendezvous)
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousUseCase.kt
@@ -1,0 +1,34 @@
+package com.zoin.rendezvous.domain.rendezvous.usecase
+
+import com.zoin.rendezvous.domain.rendezvous.Rendezvous
+import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import javax.inject.Named
+
+@Named
+class ReadRendezvousUseCase(
+    private val rendezvousRepository: RendezvousRepository,
+    private val userRepository: UserRepository,
+) {
+    data class Query(
+        val id: Long,
+        val userId: Long,
+    )
+
+    data class RendezvousAndReader(
+        val rendezvous: Rendezvous,
+        val isAuthor: Boolean,
+    )
+
+    fun execute(query: Query): RendezvousAndReader {
+        val (rendezvousId, userId) = query
+        val reader =
+            userRepository.findById(userId).orElseThrow { IllegalArgumentException("User not found. id: $userId") }
+        val rendezvous = rendezvousRepository.findById(rendezvousId)
+            .orElseThrow { IllegalArgumentException("Rendezvous not found. id: $rendezvousId") }
+        return RendezvousAndReader(
+            rendezvous,
+            reader == rendezvous.creator
+        )
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/UpdateRendezvousUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/UpdateRendezvousUseCase.kt
@@ -1,0 +1,43 @@
+package com.zoin.rendezvous.domain.rendezvous.usecase
+
+import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import java.time.LocalDateTime
+import javax.inject.Named
+import javax.transaction.Transactional
+
+@Named
+class UpdateRendezvousUseCase(
+    private val rendezvousRepository: RendezvousRepository,
+    private val userRepository: UserRepository,
+) {
+    data class Command(
+        val userId: Long,
+        val rendezvousId: Long,
+        val title: String,
+        val appointmentTime: LocalDateTime,
+        val location: String,
+        val requiredParticipantsCount: Int,
+        val description: String? = null,
+    )
+
+    @Transactional
+    fun execute(command: Command) {
+        val updateAgent =
+            userRepository.findById(command.userId)
+                .orElseThrow { IllegalArgumentException("User not found. user id: ${command.userId}") }
+        val rendezvous = rendezvousRepository.findById(command.rendezvousId)
+            .orElseThrow { IllegalArgumentException("Rendezvous not found. rendezvous id: ${command.rendezvousId}") }
+
+        if (rendezvous.creator != updateAgent) throw IllegalAccessException("Only creator can update rendezvous.")
+
+        rendezvous.updateByCreator(
+            title = command.title,
+            appointmentTime = command.appointmentTime,
+            location = command.location,
+            requiredParticipantsCount = command.requiredParticipantsCount,
+            description = command.description,
+        )
+        rendezvousRepository.save(rendezvous)
+    }
+}

--- a/rendezvous-rest/build.gradle.kts
+++ b/rendezvous-rest/build.gradle.kts
@@ -1,3 +1,7 @@
+// plugins {
+//     id("org.asciidoctor.jvm.convert")
+// }
+
 dependencies {
     implementation(project(":rendezvous-core"))
     implementation(project(":rendezvous-infra"))
@@ -16,4 +20,24 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:_")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:_")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:_")
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc:_")
 }
+
+// val asciidocSnippetsDir by extra { file("build/generated-snippets") }
+//
+// tasks.test {
+//     outputs.dir(asciidocSnippetsDir)
+// }
+//
+// tasks.asciidoctor {
+//     inputs.dir(file(asciidocSnippetsDir))
+//     attributes(mapOf("snippets" to asciidocSnippetsDir))
+//     dependsOn(tasks.test)
+// }
+//
+// tasks.bootJar {
+//     dependsOn(tasks.asciidoctor)
+//     from("${project.buildDir}/docs/asciidoc") {
+//         into("static/docs")
+//     }
+// }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
@@ -3,9 +3,12 @@ package com.zoin.rendezvous.api
 import com.zoin.rendezvous.api.`interface`.Response
 import com.zoin.rendezvous.api.`interface`.dto.CreateRendezvousReqDto
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
+import com.zoin.rendezvous.domain.rendezvous.usecase.ReadRendezvousUseCase
 import com.zoin.rendezvous.resolver.AuthTokenPayload
 import com.zoin.rendezvous.util.authToken.TokenPayload
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/rendezvous")
 class RendezvousController(
     private val createRendezvousUseCase: CreateRendezvousUseCase,
+    private val readRendezvousUseCase: ReadRendezvousUseCase,
 
 ) {
     @PostMapping("")
@@ -38,6 +42,24 @@ class RendezvousController(
         return Response(
             status = HttpStatus.OK.value(),
             message = "성공"
+        )
+    }
+
+    @GetMapping("/{id}")
+    fun getRendezvous(
+        @AuthTokenPayload payload: TokenPayload,
+        @PathVariable(value = "id") rendezvousId: Long,
+    ): Response<ReadRendezvousUseCase.RendezvousAndReader> {
+        val rendezvousAndReader = readRendezvousUseCase.execute(
+            ReadRendezvousUseCase.Query(
+                rendezvousId,
+                payload.userId
+            )
+        )
+        return Response(
+            status = HttpStatus.OK.value(),
+            message = "번개 조회 성공",
+            data = rendezvousAndReader
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
@@ -1,15 +1,17 @@
 package com.zoin.rendezvous.api
 
 import com.zoin.rendezvous.api.`interface`.Response
-import com.zoin.rendezvous.api.`interface`.dto.CreateRendezvousReqDto
+import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.ReadRendezvousUseCase
+import com.zoin.rendezvous.domain.rendezvous.usecase.UpdateRendezvousUseCase
 import com.zoin.rendezvous.resolver.AuthTokenPayload
 import com.zoin.rendezvous.util.authToken.TokenPayload
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -19,18 +21,18 @@ import org.springframework.web.bind.annotation.RestController
 class RendezvousController(
     private val createRendezvousUseCase: CreateRendezvousUseCase,
     private val readRendezvousUseCase: ReadRendezvousUseCase,
-
+    private val updateRendezvousUseCase: UpdateRendezvousUseCase,
 ) {
     @PostMapping("")
     fun createRendezvous(
         @AuthTokenPayload payload: TokenPayload,
-        @RequestBody req: CreateRendezvousReqDto,
+        @RequestBody req: SaveRendezvousReqDto,
     ): Response<Unit> {
         val (userId) = payload
 
         createRendezvousUseCase.execute(
             command = CreateRendezvousUseCase.Command(
-                userId = userId,
+                creatorId = userId,
                 title = req.title,
                 appointmentTime = req.appointmentTime,
                 location = req.location,
@@ -60,6 +62,28 @@ class RendezvousController(
             status = HttpStatus.OK.value(),
             message = "번개 조회 성공",
             data = rendezvousAndReader
+        )
+    }
+
+    @PutMapping("/{id}")
+    fun putRendezvous(
+        @AuthTokenPayload payload: TokenPayload,
+        @PathVariable(value = "id") rendezvousId: Long,
+        @RequestBody updateRendezvousReq: SaveRendezvousReqDto,
+    ): Response<Unit> {
+        updateRendezvousUseCase.execute(
+            UpdateRendezvousUseCase.Command(
+                userId = payload.userId,
+                rendezvousId = rendezvousId,
+                title = updateRendezvousReq.title,
+                appointmentTime = updateRendezvousReq.appointmentTime,
+                location = updateRendezvousReq.location,
+                requiredParticipantsCount = updateRendezvousReq.requiredParticipantsCount,
+                description = updateRendezvousReq.description,
+            )
+        )
+        return Response(
+            message = "번개 업데이트 성공",
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
@@ -3,11 +3,13 @@ package com.zoin.rendezvous.api
 import com.zoin.rendezvous.api.`interface`.Response
 import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
+import com.zoin.rendezvous.domain.rendezvous.usecase.DeleteRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.ReadRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.UpdateRendezvousUseCase
 import com.zoin.rendezvous.resolver.AuthTokenPayload
 import com.zoin.rendezvous.util.authToken.TokenPayload
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,6 +24,7 @@ class RendezvousController(
     private val createRendezvousUseCase: CreateRendezvousUseCase,
     private val readRendezvousUseCase: ReadRendezvousUseCase,
     private val updateRendezvousUseCase: UpdateRendezvousUseCase,
+    private val deleteRendezvousUseCase: DeleteRendezvousUseCase,
 ) {
     @PostMapping("")
     fun createRendezvous(
@@ -84,6 +87,22 @@ class RendezvousController(
         )
         return Response(
             message = "번개 업데이트 성공",
+        )
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteRendezvous(
+        @AuthTokenPayload payload: TokenPayload,
+        @PathVariable(value = "id") rendezvousId: Long,
+    ): Response<Unit> {
+        deleteRendezvousUseCase.execute(
+            DeleteRendezvousUseCase.Command(
+                userId = payload.userId,
+                rendezvousId = rendezvousId,
+            )
+        )
+        return Response(
+            message = "번개 삭제 성공"
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/RendezvousController.kt
@@ -1,0 +1,43 @@
+package com.zoin.rendezvous.api
+
+import com.zoin.rendezvous.api.`interface`.Response
+import com.zoin.rendezvous.api.`interface`.dto.CreateRendezvousReqDto
+import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
+import com.zoin.rendezvous.resolver.AuthTokenPayload
+import com.zoin.rendezvous.util.authToken.TokenPayload
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/rendezvous")
+class RendezvousController(
+    private val createRendezvousUseCase: CreateRendezvousUseCase,
+
+) {
+    @PostMapping("")
+    fun createRendezvous(
+        @AuthTokenPayload payload: TokenPayload,
+        @RequestBody req: CreateRendezvousReqDto,
+    ): Response<Unit> {
+        val (userId) = payload
+
+        createRendezvousUseCase.execute(
+            command = CreateRendezvousUseCase.Command(
+                userId = userId,
+                title = req.title,
+                appointmentTime = req.appointmentTime,
+                location = req.location,
+                requiredParticipantsCount = req.requiredParticipantsCount,
+                description = req.description,
+            )
+        )
+
+        return Response(
+            status = HttpStatus.OK.value(),
+            message = "성공"
+        )
+    }
+}

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/CreateRendezvousReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/CreateRendezvousReqDto.kt
@@ -1,0 +1,11 @@
+package com.zoin.rendezvous.api.`interface`.dto
+
+import java.time.LocalDateTime
+
+data class CreateRendezvousReqDto(
+    val title: String,
+    val appointmentTime: LocalDateTime,
+    val location: String,
+    val requiredParticipantsCount: Int,
+    val description: String? = null,
+)

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/SaveRendezvousReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/SaveRendezvousReqDto.kt
@@ -2,7 +2,7 @@ package com.zoin.rendezvous.api.`interface`.dto
 
 import java.time.LocalDateTime
 
-data class CreateRendezvousReqDto(
+data class SaveRendezvousReqDto(
     val title: String,
     val appointmentTime: LocalDateTime,
     val location: String,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/config/ObjectMapperConfig.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/config/ObjectMapperConfig.kt
@@ -19,7 +19,7 @@ class ObjectMapperConfig {
         .registerKotlinModule()
         .registerModule(
             JavaTimeModule().apply {
-                val dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                val dateTimeFormat = DateTimeFormatter.ISO_LOCAL_DATE_TIME
                 this.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer(dateTimeFormat))
                 this.addDeserializer(LocalDateTime::class.java, LocalDateTimeDeserializer(dateTimeFormat))
             }

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
@@ -2,7 +2,7 @@ package com.zoin.rendezvous.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
-import com.zoin.rendezvous.api.`interface`.dto.CreateRendezvousReqDto
+import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.config.mock.MockConfiguration
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
 import io.kotest.core.spec.IsolationMode
@@ -38,7 +38,7 @@ class RendezvousControllerTest(
         this.isolationMode = IsolationMode.InstancePerLeaf
 
         this.describe("Rendezvous controller는") {
-            val mockCreateRendezvousReqDto = CreateRendezvousReqDto(
+            val mockCreateRendezvousReqDto = SaveRendezvousReqDto(
                 title = "mockTitle",
                 appointmentTime = LocalDateTime.now(),
                 location = "mockLocation",

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
@@ -1,0 +1,64 @@
+package com.zoin.rendezvous.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.zoin.rendezvous.api.`interface`.dto.CreateRendezvousReqDto
+import com.zoin.rendezvous.config.mock.MockConfiguration
+import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+import kotlin.random.Random
+
+@Import(
+    MockConfiguration::class
+)
+@WebMvcTest(RendezvousController::class)
+@AutoConfigureRestDocs
+class RendezvousControllerTest(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+) : DescribeSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    @MockkBean(relaxed = true)
+    private lateinit var mockCreateRendezvousUseCase: CreateRendezvousUseCase
+
+    init {
+        this.isolationMode = IsolationMode.InstancePerLeaf
+
+        this.describe("Rendezvous controller는") {
+            val mockCreateRendezvousReqDto = CreateRendezvousReqDto(
+                title = "mockTitle",
+                appointmentTime = LocalDateTime.now(),
+                location = "mockLocation",
+                requiredParticipantsCount = Random.nextInt(100),
+                description = "mockDescription",
+            )
+            context("정상적인 post 요청에") {
+                it("성공 응답한다") {
+                    mockMvc.perform(
+                        post("/api/v1/rendezvous")
+                            .header("Authorization", "mock json web token")
+                            .content(objectMapper.writeValueAsString(mockCreateRendezvousReqDto))
+                            .contentType(MediaType.APPLICATION_JSON)
+                    )
+                        .andExpect(status().isOk)
+                        .andDo(
+                            document("rendezvous/post-rendezvous")
+                        )
+                }
+            }
+        }
+    }
+}

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/config/mock/MockAuthTokenUtil.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/config/mock/MockAuthTokenUtil.kt
@@ -1,0 +1,16 @@
+package com.zoin.rendezvous.config.mock
+
+import com.zoin.rendezvous.util.authToken.AuthTokenUtil
+import com.zoin.rendezvous.util.authToken.TokenPayload
+
+class MockAuthTokenUtil : AuthTokenUtil {
+    override fun generateToken(payload: TokenPayload): String {
+        return "mock return value"
+    }
+
+    override fun decodeToken(token: String): TokenPayload {
+        return TokenPayload(
+            userId = 1
+        )
+    }
+}

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/config/mock/MockConfiguration.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/config/mock/MockConfiguration.kt
@@ -1,0 +1,10 @@
+package com.zoin.rendezvous.config.mock
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class MockConfiguration {
+    @Bean
+    fun authTokenUtil() = MockAuthTokenUtil()
+}


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.

D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-1



**변경사항**

- closes: #18 
- 번개 CRUD API 를 만들었어요

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 전역 object mapper의 datetime 포맷을 ISO.DATETIME으로 변경했어요
- 삭제된 번개를 조회하지 않기 위한 메서드를 만들기위해 custom repository 인터페이스와 구현체를 만들었어요. 여기서 고민은.. 뭔가 점점 복잡해지는 것 같아 다른 방법을 생각해봐야하나 싶은거죠
  - jpa가 일반 조회를 할 때 deletedAt이 null 이 아닌 필드를 가져오지 않게 설정하는게 나으려나요?
  - 근데 이러면 나중에 어드민에서 보고 싶어도 jpa 를 사용할 수 없어용

**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->

- 그리고 spring rest docs를 적용하려고 하는데 문제가 있어서 잠시 스크립트에서 플러그인 태스크를 주석처리 해놓았어요.. 🤦🏻‍♀️