### PR TITLE
[FEAT] 메인 번개리스트 조회 API

### DIFF
--- a/rendezvous-core/build.gradle.kts
+++ b/rendezvous-core/build.gradle.kts
@@ -1,11 +1,15 @@
 plugins {
     id("org.jetbrains.kotlin.plugin.jpa") version "1.6.21"
+    kotlin("kapt")
 }
 
 dependencies {
     implementation("javax.inject:javax.inject:_")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:_")
     implementation("mysql:mysql-connector-java:_")
+
+    implementation("com.querydsl:querydsl-jpa:_")
+    kapt("com.querydsl:querydsl-apt:_:jpa")
 }
 
 val jar: Jar by tasks
@@ -13,3 +17,16 @@ val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
 
 bootJar.enabled = false
 jar.enabled = true
+
+sourceSets {
+    main {
+        java {
+            setSrcDirs(
+                listOf(
+                    projectDir.path + "/src/main/kotlin",
+                    projectDir.path + "/build/generated"
+                )
+            )
+        }
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/configuration/JPAQueryFactory.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/configuration/JPAQueryFactory.kt
@@ -1,0 +1,16 @@
+package com.zoin.rendezvous.configuration
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class JPAQueryFactory(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/PageByCursor.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/PageByCursor.kt
@@ -1,0 +1,6 @@
+package com.zoin.rendezvous.domain
+
+class PageByCursor<T>(
+    val elements: List<T>,
+    val hasNext: Boolean,
+)

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/Rendezvous.kt
@@ -5,6 +5,7 @@ import com.zoin.rendezvous.base.SoftDeletable
 import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousParticipantRepository
 import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
 import com.zoin.rendezvous.domain.user.User
+import com.zoin.rendezvous.domain.user.UserVO
 import org.hibernate.annotations.SQLDelete
 import java.time.LocalDateTime
 import javax.persistence.Entity
@@ -119,5 +120,31 @@ class Rendezvous(
 
     override fun toString(): String {
         return "Rendezvous(author=$creator, deletedAt=$deletedAt, id=$id, title='$title', datetime=$appointmentTime, place='$location', discription=$description)"
+    }
+}
+
+data class RendezvousVO(
+    val id: Long,
+    val creator: UserVO,
+    val title: String,
+    val location: String,
+    val requiredParticipantsCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val participants: List<UserVO>? = null,
+    val description: String? = null,
+) {
+    companion object {
+        fun of(rendezvous: Rendezvous, includeParticipants: Boolean = false) = RendezvousVO(
+            id = rendezvous.mustGetId(),
+            creator = UserVO.of(rendezvous.creator),
+            title = rendezvous.title,
+            location = rendezvous.location,
+            requiredParticipantsCount = rendezvous.requiredParticipantsCount,
+            createdAt = rendezvous.createdAt,
+            updatedAt = rendezvous.updatedAt,
+            description = rendezvous.description,
+            participants = if (includeParticipants) rendezvous.participants.map { UserVO.of(it.participant) } else null
+        )
     }
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/RendezvousParticipant.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/RendezvousParticipant.kt
@@ -1,0 +1,46 @@
+package com.zoin.rendezvous.domain.rendezvous
+
+import com.zoin.rendezvous.base.JpaBaseEntity
+import com.zoin.rendezvous.domain.user.User
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "user_participated_in_rendezvous")
+class RendezvousParticipant(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+    rendezvous: Rendezvous,
+    user: User,
+) : JpaBaseEntity() {
+    @ManyToOne
+    @JoinColumn(name = "rendezvous_id")
+    var rendezvous: Rendezvous = rendezvous
+        private set
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    var participant: User = user
+        private set
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RendezvousParticipant
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousCustomRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousCustomRepository.kt
@@ -4,4 +4,6 @@ import com.zoin.rendezvous.domain.rendezvous.Rendezvous
 
 interface RendezvousCustomRepository {
     fun findByIdExcludeDeleted(id: Long): Rendezvous
+    fun findPageByCursorLimitSize(size: Long, cursorId: Long?): List<Rendezvous>
+    fun hasNextElement(endId: Long): Boolean
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousParticipantRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousParticipantRepository.kt
@@ -1,0 +1,6 @@
+package com.zoin.rendezvous.domain.rendezvous.repository
+
+import com.zoin.rendezvous.domain.rendezvous.RendezvousParticipant
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RendezvousParticipantRepository : JpaRepository<RendezvousParticipant, Long>

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepositoryImpl.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/repository/RendezvousRepositoryImpl.kt
@@ -1,16 +1,40 @@
 package com.zoin.rendezvous.domain.rendezvous.repository
 
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.zoin.rendezvous.domain.rendezvous.QRendezvous.rendezvous
 import com.zoin.rendezvous.domain.rendezvous.Rendezvous
 import org.springframework.stereotype.Component
-import java.lang.IllegalArgumentException
 
 @Component
 class RendezvousRepositoryImpl(
     private val rendezvousJpaRepository: RendezvousJpaRepository,
+    private val queryFactory: JPAQueryFactory,
 ) : RendezvousCustomRepository {
     override fun findByIdExcludeDeleted(id: Long): Rendezvous {
-        val rendezvous = rendezvousJpaRepository.findById(id).orElseThrow { IllegalArgumentException("Rendezvous not found. id: $id") }
+        val rendezvous = rendezvousJpaRepository.findById(id)
+            .orElseThrow { IllegalArgumentException("Rendezvous not found. id: $id") }
         if (rendezvous.deletedAt != null) throw IllegalStateException("The rendezvous(id: $id) was deleted.")
         return rendezvous
+    }
+
+    override fun findPageByCursorLimitSize(size: Long, cursorId: Long?): List<Rendezvous> {
+        val predicate = BooleanBuilder(rendezvous.deletedAt.isNull)
+        if (cursorId != null) predicate.and(rendezvous.id.lt(cursorId))
+
+        return queryFactory.selectFrom(rendezvous)
+            .where(predicate)
+            .limit(size)
+            .orderBy(rendezvous.createdAt.desc())
+            .fetch()
+    }
+
+    override fun hasNextElement(endId: Long): Boolean {
+        val notDeleted = BooleanBuilder(rendezvous.deletedAt.isNull)
+        return queryFactory.selectFrom(rendezvous)
+            .where(notDeleted.and(rendezvous.id.lt(endId)))
+            .orderBy(rendezvous.createdAt.desc())
+            .limit(1)
+            .fetch().isNotEmpty()
     }
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousListUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousListUseCase.kt
@@ -1,0 +1,26 @@
+package com.zoin.rendezvous.domain.rendezvous.usecase
+
+import com.zoin.rendezvous.domain.PageByCursor
+import com.zoin.rendezvous.domain.rendezvous.RendezvousVO
+import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
+import javax.inject.Named
+
+@Named
+class ReadRendezvousListUseCase(
+    private val rendezvousRepository: RendezvousRepository,
+) {
+    data class Query(
+        val size: Long,
+        val cursorId: Long? = null,
+    )
+
+    fun execute(query: Query): PageByCursor<RendezvousVO> {
+        val rendezvous = rendezvousRepository.findPageByCursorLimitSize(query.size, query.cursorId)
+        return PageByCursor(
+            rendezvous.map {
+                RendezvousVO.of(it, true)
+            },
+            rendezvous.isNotEmpty() && rendezvousRepository.hasNextElement(rendezvous[rendezvous.size - 1].mustGetId())
+        )
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousListUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/rendezvous/usecase/ReadRendezvousListUseCase.kt
@@ -1,7 +1,6 @@
 package com.zoin.rendezvous.domain.rendezvous.usecase
 
-import com.zoin.rendezvous.domain.PageByCursor
-import com.zoin.rendezvous.domain.rendezvous.RendezvousVO
+import com.zoin.rendezvous.domain.rendezvous.Rendezvous
 import com.zoin.rendezvous.domain.rendezvous.repository.RendezvousRepository
 import javax.inject.Named
 
@@ -14,13 +13,9 @@ class ReadRendezvousListUseCase(
         val cursorId: Long? = null,
     )
 
-    fun execute(query: Query): PageByCursor<RendezvousVO> {
-        val rendezvous = rendezvousRepository.findPageByCursorLimitSize(query.size, query.cursorId)
-        return PageByCursor(
-            rendezvous.map {
-                RendezvousVO.of(it, true)
-            },
-            rendezvous.isNotEmpty() && rendezvousRepository.hasNextElement(rendezvous[rendezvous.size - 1].mustGetId())
-        )
+    fun execute(query: Query): Pair<List<Rendezvous>, Boolean> {
+        val rendezvousList = rendezvousRepository.findPageByCursorLimitSize(query.size, query.cursorId)
+        val hasNext = rendezvousList.isNotEmpty() && rendezvousRepository.hasNextElement(rendezvousList[rendezvousList.size - 1].mustGetId())
+        return rendezvousList to hasNext
     }
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/user/User.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/user/User.kt
@@ -106,3 +106,27 @@ class User(
         return result
     }
 }
+
+data class UserVO(
+    val id: Long,
+    val serviceId: String,
+    val userName: String,
+    val email: String,
+    val profileImgUrl: String? = null,
+    var agreedToPushNotifications: Boolean,
+    var createdAt: LocalDateTime,
+    var updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun of(user: User) = UserVO(
+            id = user.mustGetId(),
+            serviceId = user.serviceId,
+            userName = user.userName,
+            email = user.email,
+            profileImgUrl = user.profileImgUrl,
+            agreedToPushNotifications = user.agreedToPushNotifications,
+            createdAt = user.createdAt,
+            updatedAt = user.updatedAt,
+        )
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/user/User.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/user/User.kt
@@ -11,7 +11,6 @@ import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
-import javax.persistence.ManyToMany
 import javax.persistence.OneToMany
 import javax.persistence.Table
 
@@ -58,19 +57,14 @@ class User(
     var profileImgUrl: String? = profileImgUrl
         private set
 
+    // TODO: 필드를 도메인 모델에서 제거. (분리하기)
     var agreedToPushNotifications: Boolean = agreedToPushNotifications
         private set
 
     @OneToMany(mappedBy = "creator", fetch = FetchType.LAZY)
     var madeRendezvous: List<Rendezvous> = listOf()
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    var belongsToRendezvous: List<Rendezvous> = listOf()
-
-    fun participateRendezvous(rendezvous: Rendezvous) {
-        if (rendezvous.isClosed()) throw IllegalAccessException("이미 마감된 번개입니다.")
-        rendezvous.addNewParticipant(this)
-    }
+    fun mustGetId() = id ?: throw IllegalStateException("Entity doesn't have ID.")
 
     fun deleteRendezvous(rendezvousRepository: RendezvousRepository, rendezvous: Rendezvous) {
         val mutableRendezvousList = madeRendezvous.toMutableList()

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/common/PageByCursor.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/common/PageByCursor.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.domain
+package com.zoin.rendezvous.api.common
 
 class PageByCursor<T>(
     val elements: List<T>,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/common/Response.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/common/Response.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`
+package com.zoin.rendezvous.api.common
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.LocalDateTime

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/GetMainReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/interface/dto/GetMainReqDto.kt
@@ -1,0 +1,6 @@
+package com.zoin.rendezvous.api.`interface`.dto
+
+data class GetMainReqDto(
+    val size: Long,
+    val cursorId: Long? = null,
+)

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
@@ -1,9 +1,9 @@
 package com.zoin.rendezvous.api.rendezvous
 
-import com.zoin.rendezvous.api.`interface`.Response
+import com.zoin.rendezvous.api.common.PageByCursor
+import com.zoin.rendezvous.api.common.Response
 import com.zoin.rendezvous.api.rendezvous.dto.GetMainReqDto
 import com.zoin.rendezvous.api.rendezvous.dto.SaveRendezvousReqDto
-import com.zoin.rendezvous.domain.PageByCursor
 import com.zoin.rendezvous.domain.rendezvous.RendezvousVO
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.DeleteRendezvousUseCase
@@ -117,7 +117,7 @@ class RendezvousController(
         @RequestBody getMainReqDto: GetMainReqDto,
     ): Response<PageByCursor<RendezvousVO>> {
         val (size, cursorId) = getMainReqDto
-        val page = readRendezvousListUseCase.execute(
+        val (rendezvousList, hasNext) = readRendezvousListUseCase.execute(
             ReadRendezvousListUseCase.Query(
                 size,
                 cursorId,
@@ -125,7 +125,12 @@ class RendezvousController(
         )
         return Response(
             message = "메인 번개 리스트 조회 성공",
-            data = page,
+            data = PageByCursor(
+                elements = rendezvousList.map { rendezvous ->
+                    RendezvousVO.of(rendezvous, true)
+                },
+                hasNext
+            ),
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
@@ -1,9 +1,13 @@
-package com.zoin.rendezvous.api
+package com.zoin.rendezvous.api.rendezvous
 
 import com.zoin.rendezvous.api.`interface`.Response
+import com.zoin.rendezvous.api.`interface`.dto.GetMainReqDto
 import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
+import com.zoin.rendezvous.domain.PageByCursor
+import com.zoin.rendezvous.domain.rendezvous.RendezvousVO
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.DeleteRendezvousUseCase
+import com.zoin.rendezvous.domain.rendezvous.usecase.ReadRendezvousListUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.ReadRendezvousUseCase
 import com.zoin.rendezvous.domain.rendezvous.usecase.UpdateRendezvousUseCase
 import com.zoin.rendezvous.resolver.AuthTokenPayload
@@ -25,6 +29,7 @@ class RendezvousController(
     private val readRendezvousUseCase: ReadRendezvousUseCase,
     private val updateRendezvousUseCase: UpdateRendezvousUseCase,
     private val deleteRendezvousUseCase: DeleteRendezvousUseCase,
+    private val readRendezvousListUseCase: ReadRendezvousListUseCase,
 ) {
     @PostMapping("")
     fun createRendezvous(
@@ -103,6 +108,24 @@ class RendezvousController(
         )
         return Response(
             message = "번개 삭제 성공"
+        )
+    }
+
+    @GetMapping("/main")
+    fun getMain(
+        @AuthTokenPayload payload: TokenPayload,
+        @RequestBody getMainReqDto: GetMainReqDto,
+    ): Response<PageByCursor<RendezvousVO>> {
+        val (size, cursorId) = getMainReqDto
+        val page = readRendezvousListUseCase.execute(
+            ReadRendezvousListUseCase.Query(
+                size,
+                cursorId,
+            )
+        )
+        return Response(
+            message = "메인 번개 리스트 조회 성공",
+            data = page,
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/RendezvousController.kt
@@ -1,8 +1,8 @@
 package com.zoin.rendezvous.api.rendezvous
 
 import com.zoin.rendezvous.api.`interface`.Response
-import com.zoin.rendezvous.api.`interface`.dto.GetMainReqDto
-import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
+import com.zoin.rendezvous.api.rendezvous.dto.GetMainReqDto
+import com.zoin.rendezvous.api.rendezvous.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.domain.PageByCursor
 import com.zoin.rendezvous.domain.rendezvous.RendezvousVO
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/dto/GetMainReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/dto/GetMainReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.rendezvous.dto
 
 data class GetMainReqDto(
     val size: Long,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/dto/SaveRendezvousReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/rendezvous/dto/SaveRendezvousReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.rendezvous.dto
 
 import java.time.LocalDateTime
 

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/UserController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/UserController.kt
@@ -1,6 +1,6 @@
 package com.zoin.rendezvous.api.user
 
-import com.zoin.rendezvous.api.`interface`.Response
+import com.zoin.rendezvous.api.common.Response
 import com.zoin.rendezvous.api.user.dto.CheckExistingServiceIdReqDto
 import com.zoin.rendezvous.api.user.dto.CheckExitingEmailReqDto
 import com.zoin.rendezvous.api.user.dto.SetUserNotificationReqDto

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/UserController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/UserController.kt
@@ -1,14 +1,14 @@
 package com.zoin.rendezvous.api.user
 
 import com.zoin.rendezvous.api.`interface`.Response
-import com.zoin.rendezvous.api.`interface`.dto.CheckExistingServiceIdReqDto
-import com.zoin.rendezvous.api.`interface`.dto.CheckExitingEmailReqDto
-import com.zoin.rendezvous.api.`interface`.dto.SetUserNotificationReqDto
-import com.zoin.rendezvous.api.`interface`.dto.UpdateUserProfileImageReqDto
-import com.zoin.rendezvous.api.`interface`.dto.UpdateUserProfileImageResDto
-import com.zoin.rendezvous.api.`interface`.dto.UserLogInReqDto
-import com.zoin.rendezvous.api.`interface`.dto.UserSignUpReqDto
-import com.zoin.rendezvous.api.`interface`.dto.VerifyEmailReqDto
+import com.zoin.rendezvous.api.user.dto.CheckExistingServiceIdReqDto
+import com.zoin.rendezvous.api.user.dto.CheckExitingEmailReqDto
+import com.zoin.rendezvous.api.user.dto.SetUserNotificationReqDto
+import com.zoin.rendezvous.api.user.dto.UpdateUserProfileImageReqDto
+import com.zoin.rendezvous.api.user.dto.UpdateUserProfileImageResDto
+import com.zoin.rendezvous.api.user.dto.UserLogInReqDto
+import com.zoin.rendezvous.api.user.dto.UserSignUpReqDto
+import com.zoin.rendezvous.api.user.dto.VerifyEmailReqDto
 import com.zoin.rendezvous.domain.user.usecase.CheckAlreadyExistingEmailUseCase
 import com.zoin.rendezvous.domain.user.usecase.CheckAlreadyExistingServiceIdUseCase
 import com.zoin.rendezvous.domain.user.usecase.CreateUserUseCase
@@ -27,8 +27,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/user")
-class Controller(
+@RequestMapping("/api/v1/user")
+class UserController(
     private val createUserUseCase: CreateUserUseCase,
     private val loginUseCase: LoginUseCase,
     private val updateUserProfileImageUseCase: UpdateUserProfileImageUseCase,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/CheckExistingServiceIdReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/CheckExistingServiceIdReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class CheckExistingServiceIdReqDto(
     val serviceId: String

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/CheckExitingEmailReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/CheckExitingEmailReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class CheckExitingEmailReqDto(
     val email: String,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/SetUserNotificationReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/SetUserNotificationReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class SetUserNotificationReqDto(
     val on: Boolean,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UpdateUserProfileImageDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UpdateUserProfileImageDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 class UpdateUserProfileImageReqDto(
     val profileImgUrl: String

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UserLogInReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UserLogInReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class UserLogInReqDto(
     val email: String,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UserSignUpReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/UserSignUpReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class UserSignUpReqDto(
     val email: String,

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/VerifyEmailReqDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/user/dto/VerifyEmailReqDto.kt
@@ -1,4 +1,4 @@
-package com.zoin.rendezvous.api.`interface`.dto
+package com.zoin.rendezvous.api.user.dto
 
 data class VerifyEmailReqDto(
     val email: String

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/support/GlobalExceptionHandler.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/support/GlobalExceptionHandler.kt
@@ -1,6 +1,6 @@
 package com.zoin.rendezvous.support
 
-import com.zoin.rendezvous.api.`interface`.Response
+import com.zoin.rendezvous.api.common.Response
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
@@ -2,7 +2,7 @@ package com.zoin.rendezvous.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
-import com.zoin.rendezvous.api.`interface`.dto.SaveRendezvousReqDto
+import com.zoin.rendezvous.api.rendezvous.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.config.mock.MockConfiguration
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase
 import io.kotest.core.spec.IsolationMode

--- a/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
+++ b/rendezvous-rest/src/test/kotlin/com/zoin/rendezvous/api/RendezvousControllerTest.kt
@@ -2,6 +2,7 @@ package com.zoin.rendezvous.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import com.zoin.rendezvous.api.rendezvous.RendezvousController
 import com.zoin.rendezvous.api.rendezvous.dto.SaveRendezvousReqDto
 import com.zoin.rendezvous.config.mock.MockConfiguration
 import com.zoin.rendezvous.domain.rendezvous.usecase.CreateRendezvousUseCase

--- a/versions.properties
+++ b/versions.properties
@@ -11,6 +11,10 @@ version.com.fasterxml.jackson.module..jackson-module-kotlin=2.13.2
 
 version.com.ninja-squad..springmockk=3.1.1
 
+version.com.querydsl..querydsl-apt=5.0.0
+
+version.com.querydsl..querydsl-jpa=5.0.0
+
 version.com.sun.activation..jakarta.activation=2.0.1
 
 version.com.sun.mail..jakarta.mail=2.0.1

--- a/versions.properties
+++ b/versions.properties
@@ -46,3 +46,5 @@ version.org.springframework.boot..spring-boot-configuration-processor=2.6.7
 version.org.springframework.boot..spring-boot-starter-data-jpa=2.6.7
 
 version.org.springframework.boot..spring-boot-starter-mail=2.6.7
+
+version.org.springframework.restdocs..spring-restdocs-mockmvc=2.0.6.RELEASE


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.

D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-1



**변경사항**

- closes: #23 
- 번개 메인 리스트를 불러와요
- 번개 VO, 유저 VO 정의 => 엔티티 순환참조 방지, 앞으로 VO로 바꿔서 보내줄 생각입니다
- plaintext로 JPQL 사용을 지양하고자 QueryDSL을 도입했어요.


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 고민하고 있는 것이 있는디: 번개 참여자 수만 가져오면 되는데 굳이 User 엔티티 다 가져오고 있는 것
  ```kotlin
  // RendezvousVO 생성자
  participants = if (includeParticipants) rendezvous.participants.map { UserVO.of(it.participant) } else null
  ```
- 실행하기 전에 QueryDSL의 task 로 Qclass 들을 만들어줘야해요.

  터미널에서 실행해주세요.  
  ```
   ./gradlew :rendezvous-core:complieKotlin
  ```
  또는 요거 눌러주셔도 되궁.

  <img width="291" alt="image" src="https://user-images.githubusercontent.com/61582017/170057227-89eb54f6-6af5-4059-8529-519a8e2c7dec.png">
