### PR TITLE
[FEAT] 친구 신청 기능

### DIFF
--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
@@ -29,6 +29,12 @@ class Friend(
     var status: Status = status
         private set
 
+    fun isFriend() = status == Status.FRIEND
+
+    fun acceptFriendRequest() {
+        status = Status.FRIEND
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
@@ -1,0 +1,48 @@
+package com.zoin.rendezvous.domain.friend
+
+import com.zoin.rendezvous.base.JpaBaseEntity
+import com.zoin.rendezvous.domain.user.User
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "friend")
+class Friend(
+    @ManyToOne
+    val user: User,
+    @ManyToOne
+    val friend: User,
+    status: Status,
+) : JpaBaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0
+
+    var status: Status = status
+        private set
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Friend
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: 0
+    }
+}
+
+enum class Status {
+    FRIEND,
+    PENDING
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/Friend.kt
@@ -3,6 +3,8 @@ package com.zoin.rendezvous.domain.friend
 import com.zoin.rendezvous.base.JpaBaseEntity
 import com.zoin.rendezvous.domain.user.User
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -23,6 +25,7 @@ class Friend(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0
 
+    @Enumerated(value = EnumType.STRING)
     var status: Status = status
         private set
 
@@ -39,6 +42,10 @@ class Friend(
 
     override fun hashCode(): Int {
         return id?.hashCode() ?: 0
+    }
+
+    override fun toString(): String {
+        return "Friend(user=$user, friend=$friend, id=$id)"
     }
 }
 

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepository.kt
@@ -1,0 +1,7 @@
+package com.zoin.rendezvous.domain.friend.repository
+
+import com.zoin.rendezvous.domain.user.User
+
+interface FriendCustomRepository {
+    fun ifUsersAreAlreadyFriend(user: User, other: User): Boolean
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepositoryImpl.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.zoin.rendezvous.domain.friend.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.zoin.rendezvous.domain.friend.QFriend.friend1
+import com.zoin.rendezvous.domain.user.User
+
+class FriendCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : FriendCustomRepository {
+
+    override fun ifUsersAreAlreadyFriend(user: User, other: User): Boolean {
+        return queryFactory.selectFrom(friend1)
+            .where(
+                friend1.user.eq(user).and(friend1.friend.eq(other))
+                    .or(friend1.user.eq(other).and(friend1.friend.eq(user)))
+            )
+            .fetch()
+            .isNotEmpty()
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepositoryImpl.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendCustomRepositoryImpl.kt
@@ -13,6 +13,7 @@ class FriendCustomRepositoryImpl(
             .where(
                 friend1.user.eq(user).and(friend1.friend.eq(other))
                     .or(friend1.user.eq(other).and(friend1.friend.eq(user)))
+                    .and(friend1.status.stringValue().eq("FRIEND"))
             )
             .fetch()
             .isNotEmpty()

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendJpaRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.zoin.rendezvous.domain.friend.repository
+
+import com.zoin.rendezvous.domain.friend.Friend
+import com.zoin.rendezvous.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FriendJpaRepository : JpaRepository<Friend, Long> {
+    fun findByUserAndFriend(user: User, friend: User): Friend?
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendRepository.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/repository/FriendRepository.kt
@@ -1,0 +1,3 @@
+package com.zoin.rendezvous.domain.friend.repository
+
+interface FriendRepository : FriendJpaRepository, FriendCustomRepository

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/AcceptFriendRequestUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/AcceptFriendRequestUseCase.kt
@@ -1,0 +1,29 @@
+package com.zoin.rendezvous.domain.friend.usecase
+
+import com.zoin.rendezvous.domain.friend.repository.FriendRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import javax.inject.Named
+import javax.transaction.Transactional
+
+@Named
+class AcceptFriendRequestUseCase(
+    private val userRepository: UserRepository,
+    private val friendRepository: FriendRepository,
+) {
+    data class Command(
+        val targetUserId: Long,
+        val requesterId: Long,
+    )
+
+    @Transactional
+    fun execute(command: Command) {
+        val requester = userRepository.findByIdExcludeDeleted(command.requesterId)
+        val targetUser = userRepository.findByIdExcludeDeleted(command.targetUserId)
+        val relationship = friendRepository.findByUserAndFriend(requester, targetUser)
+            ?: throw IllegalArgumentException("해당하는 친구 신청이 존재하지 않습니다.")
+        if (relationship.isFriend()) {
+            throw kotlin.IllegalStateException("이미 친구관계입니다.")
+        }
+        relationship.acceptFriendRequest()
+    }
+}

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCase.kt
@@ -3,6 +3,7 @@ package com.zoin.rendezvous.domain.friend.usecase
 import com.zoin.rendezvous.domain.friend.Friend
 import com.zoin.rendezvous.domain.friend.Status
 import com.zoin.rendezvous.domain.friend.repository.FriendRepository
+import com.zoin.rendezvous.domain.user.User
 import com.zoin.rendezvous.domain.user.repository.UserRepository
 import javax.inject.Named
 
@@ -19,10 +20,26 @@ class CreateFriendRequestUseCase(
     fun execute(command: Command) {
         val user = userRepository.findByIdExcludeDeleted(command.userId)
         val targetUser = userRepository.findByIdExcludeDeleted(command.targetUserId)
+
+        ifUsersAreAlreadyFriendThrowsException(user, targetUser)
+        val newFriendRequest = Friend(user, targetUser, Status.PENDING)
+        friendRepository.save(newFriendRequest)
+    }
+
+    fun ifUsersAreAlreadyFriendThrowsException(user: User, targetUser: User) {
+        // 이미 친구인 경우
         if (friendRepository.ifUsersAreAlreadyFriend(user, targetUser)) {
             throw IllegalStateException("이미 친구목록에 있는 친구입니다.")
         }
-        val newFriendRequest = Friend(user, targetUser, Status.PENDING)
-        friendRepository.save(newFriendRequest)
+
+        // 이미 신청을 한 사람인 경우
+        friendRepository.findByUserAndFriend(user, targetUser)?.let {
+            throw IllegalStateException("이미 친구 신청을 보냈습니다.")
+        }
+
+        // 내가 수락을 하지 않은 경우
+        friendRepository.findByUserAndFriend(targetUser, user)?.let {
+            throw IllegalStateException("나에게 이미 친구 신청을 보낸 유저입니다.")
+        }
     }
 }

--- a/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCase.kt
+++ b/rendezvous-core/src/main/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCase.kt
@@ -1,0 +1,28 @@
+package com.zoin.rendezvous.domain.friend.usecase
+
+import com.zoin.rendezvous.domain.friend.Friend
+import com.zoin.rendezvous.domain.friend.Status
+import com.zoin.rendezvous.domain.friend.repository.FriendRepository
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import javax.inject.Named
+
+@Named
+class CreateFriendRequestUseCase(
+    private val userRepository: UserRepository,
+    private val friendRepository: FriendRepository,
+) {
+    data class Command(
+        val userId: Long,
+        val targetUserId: Long,
+    )
+
+    fun execute(command: Command) {
+        val user = userRepository.findByIdExcludeDeleted(command.userId)
+        val targetUser = userRepository.findByIdExcludeDeleted(command.targetUserId)
+        if (friendRepository.ifUsersAreAlreadyFriend(user, targetUser)) {
+            throw IllegalStateException("이미 친구목록에 있는 친구입니다.")
+        }
+        val newFriendRequest = Friend(user, targetUser, Status.PENDING)
+        friendRepository.save(newFriendRequest)
+    }
+}

--- a/rendezvous-core/src/test/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCaseTest.kt
+++ b/rendezvous-core/src/test/kotlin/com/zoin/rendezvous/domain/friend/usecase/CreateFriendRequestUseCaseTest.kt
@@ -1,0 +1,139 @@
+package com.zoin.rendezvous.domain.friend.usecase
+
+import com.zoin.rendezvous.domain.friend.Friend
+import com.zoin.rendezvous.domain.friend.Status
+import com.zoin.rendezvous.domain.friend.repository.FriendRepository
+import com.zoin.rendezvous.domain.user.User
+import com.zoin.rendezvous.domain.user.repository.UserRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import kotlin.random.Random
+
+class CreateFriendRequestUseCaseTest : DescribeSpec({
+    lateinit var useCase: CreateFriendRequestUseCase
+    lateinit var mockUserRepository: UserRepository
+    lateinit var mockFriendRepository: FriendRepository
+
+    beforeTest {
+        mockUserRepository = mockk()
+        mockFriendRepository = mockk()
+        useCase = spyk(
+            objToCopy = CreateFriendRequestUseCase(
+                mockUserRepository,
+                mockFriendRepository,
+            )
+        )
+    }
+
+    describe("친구 신청 기능은") {
+        var requesterId: Long = 0
+        var targetUserId: Long = 0
+        lateinit var requester: User
+        lateinit var targetUser: User
+        beforeTest {
+            requesterId = Random.nextLong(10, 100)
+            targetUserId = Random.nextLong(10, 100)
+            requester = mockk()
+            targetUser = mockk()
+            every { mockUserRepository.findByIdExcludeDeleted(requesterId) } returns requester
+            every { mockUserRepository.findByIdExcludeDeleted(targetUserId) } returns targetUser
+        }
+        context("유저가 친구가 아닌 유저에게 사용할 때") {
+            beforeTest {
+                every {
+                    mockFriendRepository.ifUsersAreAlreadyFriend(requester, targetUser)
+                } returns false
+                every {
+                    mockFriendRepository.findByUserAndFriend(requester, targetUser)
+                } returns null
+                every {
+                    mockFriendRepository.findByUserAndFriend(targetUser, requester)
+                } returns null
+                every { mockFriendRepository.save(any()) } returns mockk()
+            }
+            it("성공한다.") {
+                assertDoesNotThrow {
+                    useCase.execute(
+                        CreateFriendRequestUseCase.Command(
+                            userId = requesterId,
+                            targetUserId = targetUserId,
+                        )
+                    )
+                }
+            }
+        }
+
+        context("유저가 이미 친구인 유저에게 사용할 때") {
+            beforeTest {
+                every { mockFriendRepository.ifUsersAreAlreadyFriend(requester, targetUser)} returns true
+            }
+            it("예외를 던진다") {
+                assertThrows<IllegalStateException> {
+                    useCase.execute(
+                        CreateFriendRequestUseCase.Command(
+                            userId = requesterId,
+                            targetUserId = targetUserId,
+                        )
+                    )
+                }
+            }
+        }
+
+        context("유저가 이미 친구신청을 했을 때") {
+            lateinit var mockFriendRelationship: Friend
+            beforeTest {
+                every { mockFriendRepository.ifUsersAreAlreadyFriend(requester, targetUser)} returns false
+                mockFriendRelationship = mockk {
+                    every { user } returns requester
+                    every { friend } returns targetUser
+                    every { status } returns Status.PENDING
+                }
+                every {
+                    mockFriendRepository.findByUserAndFriend(requester, targetUser)
+                } returns mockFriendRelationship
+            }
+            it("예외를 던진다") {
+                assertThrows<IllegalStateException> {
+                    useCase.execute(
+                        CreateFriendRequestUseCase.Command(
+                            userId = requesterId,
+                            targetUserId = targetUserId,
+                        )
+                    )
+                }
+            }
+        }
+        context("유저가 이미 친구신청을 받았을 때") {
+            lateinit var mockFriendRelationship: Friend
+            beforeTest {
+                every { mockFriendRepository.ifUsersAreAlreadyFriend(requester, targetUser)} returns false
+                mockFriendRelationship = mockk {
+                    every { user } returns targetUser
+                    every { friend } returns requester
+                    every { status } returns Status.PENDING
+                }
+                every {
+                    mockFriendRepository.findByUserAndFriend(requester, targetUser)
+                } returns null
+                every {
+                    mockFriendRepository.findByUserAndFriend(targetUser, requester)
+                } returns mockFriendRelationship
+            }
+            it("예외를 던진다") {
+                assertThrows<IllegalStateException> {
+                    useCase.execute(
+                        CreateFriendRequestUseCase.Command(
+                            userId = requesterId,
+                            targetUserId = targetUserId,
+                        )
+                    )
+                }
+            }
+        }
+
+    }
+})

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/FriendController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/FriendController.kt
@@ -1,11 +1,14 @@
 package com.zoin.rendezvous.api.friend
 
 import com.zoin.rendezvous.api.common.Response
+import com.zoin.rendezvous.api.friend.dto.AcceptFriendRequestDto
 import com.zoin.rendezvous.api.friend.dto.CreateFriendRequestDto
+import com.zoin.rendezvous.domain.friend.usecase.AcceptFriendRequestUseCase
 import com.zoin.rendezvous.domain.friend.usecase.CreateFriendRequestUseCase
 import com.zoin.rendezvous.resolver.AuthTokenPayload
 import com.zoin.rendezvous.util.authToken.TokenPayload
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/friend")
 class FriendController(
     private val createFriendRequestUseCase: CreateFriendRequestUseCase,
+    private val acceptFriendRequestUseCase: AcceptFriendRequestUseCase,
 ) {
 
     @PostMapping
@@ -29,6 +33,22 @@ class FriendController(
         )
         return Response(
             message = "친구 신청 성공"
+        )
+    }
+
+    @PutMapping
+    fun acceptFriendRequest(
+        @AuthTokenPayload payload: TokenPayload,
+        @RequestBody req: AcceptFriendRequestDto,
+    ): Response<Unit> {
+        acceptFriendRequestUseCase.execute(
+            AcceptFriendRequestUseCase.Command(
+                targetUserId = payload.userId,
+                requesterId = req.requesterId,
+            )
+        )
+        return Response(
+            message = "친구 신청 수락 성공"
         )
     }
 }

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/FriendController.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/FriendController.kt
@@ -1,0 +1,34 @@
+package com.zoin.rendezvous.api.friend
+
+import com.zoin.rendezvous.api.common.Response
+import com.zoin.rendezvous.api.friend.dto.CreateFriendRequestDto
+import com.zoin.rendezvous.domain.friend.usecase.CreateFriendRequestUseCase
+import com.zoin.rendezvous.resolver.AuthTokenPayload
+import com.zoin.rendezvous.util.authToken.TokenPayload
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/friend")
+class FriendController(
+    private val createFriendRequestUseCase: CreateFriendRequestUseCase,
+) {
+
+    @PostMapping
+    fun createFriendRequest(
+        @AuthTokenPayload payload: TokenPayload,
+        @RequestBody req: CreateFriendRequestDto,
+    ): Response<Unit> {
+        createFriendRequestUseCase.execute(
+            CreateFriendRequestUseCase.Command(
+                userId = payload.userId,
+                targetUserId = req.targetUserId,
+            )
+        )
+        return Response(
+            message = "친구 신청 성공"
+        )
+    }
+}

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/dto/AcceptFriendRequestDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/dto/AcceptFriendRequestDto.kt
@@ -1,0 +1,5 @@
+package com.zoin.rendezvous.api.friend.dto
+
+data class AcceptFriendRequestDto(
+    val requesterId: Long,
+)

--- a/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/dto/CreateFriendRequestDto.kt
+++ b/rendezvous-rest/src/main/kotlin/com/zoin/rendezvous/api/friend/dto/CreateFriendRequestDto.kt
@@ -1,0 +1,5 @@
+package com.zoin.rendezvous.api.friend.dto
+
+data class CreateFriendRequestDto(
+    val targetUserId: Long,
+)


### PR DESCRIPTION
**변경사항**

- 친구 관계 엔티티를 만들었어요.
  ```kotlin
  @Entity
  @Table(name = "friend")
  class Friend(
      @ManyToOne
      val user: User,
      @ManyToOne
      val friend: User,
      status: Status,
  ) : JpaBaseEntity() {
  
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
      var id: Long = 0
  
      @Enumerated(value = EnumType.STRING)
      var status: Status = status
          private set
  
      fun isFriend() = status == Status.FRIEND
  
      fun acceptFriendRequest() {
          status = Status.FRIEND
      }
      // 어쩌구..
  }
  
  enum class Status {
      FRIEND,
      PENDING
  }
    ```
 
- 추후에 엔티티 이름을 좀 바꾸어야겠어요.. Relationship이라던지로요.
  - 지금은 Friend 인데, 모호한 이름인 것 같아요. 보시다시피 이 테이블에 row로 있다고 해서 무조건 친구관계는 아니거든요.


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->



**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->

- [노션 api 문서](https://www.notion.so/reckontwice/c86de4dd0e9d4e3f9c978a7226bebfdc?v=1d04f3ead0cb49009d9c6684e886954d)에는 응답이 정리돼 있고요, 요청 형태는 postman 에서 봐주세요.